### PR TITLE
Add a button to mute the stream

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,9 @@
       <div class="titlebar-button" id="titlebar-autostart" title="Auto Start">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m16.56 5.44l-1.45 1.45A5.97 5.97 0 0 1 18 12a6 6 0 0 1-6 6a6 6 0 0 1-6-6c0-2.17 1.16-4.06 2.88-5.12L7.44 5.44A7.96 7.96 0 0 0 4 12a8 8 0 0 0 8 8a8 8 0 0 0 8-8c0-2.72-1.36-5.12-3.44-6.56M13 3h-2v10h2"/></svg>
       </div>
+      <div class="titlebar-button" id="titlebar-mute" title="Mute">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16"><path fill="currentColor" d="M11.243 12.993a.75.75 0 0 1-.53-1.281a5.256 5.256 0 0 0 0-7.425a.75.75 0 1 1 1.061-1.061c1.275 1.275 1.977 2.97 1.977 4.773s-.702 3.498-1.977 4.773a.75.75 0 0 1-.53.22zm-2.665-1.415a.75.75 0 0 1-.53-1.281a3.254 3.254 0 0 0 0-4.596a.75.75 0 1 1 1.061-1.061a4.756 4.756 0 0 1 0 6.718a.75.75 0 0 1-.53.22zM6.5 15a.5.5 0 0 1-.354-.146L2.292 11H.499a.5.5 0 0 1-.5-.5v-5a.5.5 0 0 1 .5-.5h1.793l3.854-3.854A.499.499 0 0 1 7 1.5v13a.5.5 0 0 1-.5.5"/></svg>
+      </div>
       <div class="titlebar-button" id="titlebar-pintotop" title="Pin to Top">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2z"/></svg>
       </div>
@@ -24,15 +27,32 @@
       </div>
     </div>
 
-    <iframe
-      width="100%"
-      height="100vh"
-      src="https://www.youtube.com/embed/thCiTnOzkOM?autoplay=1&controls=0"
-      title="Swarm FM"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      referrerpolicy="strict-origin-when-cross-origin"
-      allowfullscreen
-    ></iframe>
+    <div id="player"></div>
+    <script>
+      var tag = document.createElement('script');
+      tag.src = "https://www.youtube.com/iframe_api";
+      var firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+      var player;
+      function onYouTubeIframeAPIReady() {
+      player = new YT.Player('player', {
+        height: '100%',
+        width: '100%',
+        videoId: 'thCiTnOzkOM',
+        playerVars: {
+        'autoplay': 1,
+        'controls': 0
+        },
+        events: {
+        'onReady': onPlayerReady
+        }
+      });
+      }
+
+      function onPlayerReady(event) {
+      event.target.playVideo();
+      }
+    </script>
   </body>
 </html>

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -68,6 +68,17 @@ document.addEventListener("DOMContentLoaded", (event) => {
         }
       });
   }, 100);
+  document.getElementById("titlebar-mute").addEventListener("click", () => {
+    if (player.isMuted()) {
+      document.getElementById("titlebar-mute").querySelector("path").setAttribute("d", "M11.243 12.993a.75.75 0 0 1-.53-1.281a5.256 5.256 0 0 0 0-7.425a.75.75 0 1 1 1.061-1.061c1.275 1.275 1.977 2.97 1.977 4.773s-.702 3.498-1.977 4.773a.75.75 0 0 1-.53.22zm-2.665-1.415a.75.75 0 0 1-.53-1.281a3.254 3.254 0 0 0 0-4.596a.75.75 0 1 1 1.061-1.061a4.756 4.756 0 0 1 0 6.718a.75.75 0 0 1-.53.22zM6.5 15a.5.5 0 0 1-.354-.146L2.292 11H.499a.5.5 0 0 1-.5-.5v-5a.5.5 0 0 1 .5-.5h1.793l3.854-3.854A.499.499 0 0 1 7 1.5v13a.5.5 0 0 1-.5.5");
+      document.getElementById("titlebar-mute").querySelector("path").setAttribute("viewBox", "0 0 16 16");
+      player.unMute();
+    } else {
+      document.getElementById("titlebar-mute").querySelector("path").setAttribute("d", "M15 9.674V11h-1.326L12 9.326L10.326 11H9V9.674L10.674 8L9 6.326V5h1.326L12 6.674L13.674 5H15v1.326L13.326 8zM6.5 15a.5.5 0 0 1-.354-.146L2.292 11H.499a.5.5 0 0 1-.5-.5v-5a.5.5 0 0 1 .5-.5h1.793l3.854-3.854A.499.499 0 0 1 7 1.5v13a.5.5 0 0 1-.5.5");
+      document.getElementById("titlebar-mute").querySelector("path").setAttribute("viewBox", "0 0 512 512");
+      player.mute();
+    }
+});
 });
 
 document.onkeydown = function (e) {


### PR DESCRIPTION
This PR makes a button allowing you to mute the stream, allowing to leave the app open, but have it not play the music.

Picture of the button:
![image](https://github.com/user-attachments/assets/fb4c9ab9-8c03-42f2-a40e-a34155ce7380)
When the mute is active, it changes the icon of the button:
![image](https://github.com/user-attachments/assets/0e00fc2b-c0c1-4cb3-b110-aaa1bd0766c5)

This also switches to [YouTube's embedded player API](https://developers.google.com/youtube/iframe_api_reference), to allow for more control over the player. (so I could mute the video)