### PR TITLE
Fix the use of the new domain for the API

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,8 +14,8 @@
     "core:window:allow-set-always-on-top",
     {
       "identifier": "http:default",
-      "allow": [{ "url": "https://swarmfm.ktrain5369.me/*" }],
-      "deny": [{ "url": "https://google.com" }]
+"allow": [{ "url": "https://sw.arm.fm/*" },{ "url": "https://*.sw.arm.fm/*" }],
+      "deny": [{ "url": "https://google.com/*" }]
     }
   ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -45,17 +45,17 @@
         //var data = null
           try {
               const response = await fetch2('https://sw.arm.fm/api/livestream', {cache: "no-store"});
-              if (!response.ok) {
+              const responseData = await response.text();
+              if (!response.ok || responseData['error']) {
                   throw new Error('Network response was not ok');
               }
-              const responseData = await response.text();
               tempdata = JSON.parse(responseData);
               console.log(tempdata);
           } catch (error) {
               console.error('Error fetching livestream data:', error);
 
               try {
-                  const fallbackResponse = await fetch2('https://uptime.sw.arm.fm/', {cache: "no-store"});
+                  const fallbackResponse = await fetch2('https://uptime.sw.arm.fm/api/uptime/status', {cache: "no-store"});
                   if (!fallbackResponse.ok) {
                       throw new Error('Network response was not ok');
                   }


### PR DESCRIPTION
this was not fun to debug
thanks @KTrain5169 


This PR uses the correct api route for uptime.sw.arm.fm (see [this discord message](https://discord.com/channels/1327042091200807024/1331001835296919623/1400223670395469824)), update the error detection as /livesteam will fail but still give a 200 status code, and allow tauri to access the new domain(s).